### PR TITLE
[RFC] vim-patch:8.1.0449,8.1.0450

### DIFF
--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1460,7 +1460,13 @@ static void win_update(win_T *wp)
       if (wp->w_p_rnu) {
         // 'relativenumber' set: The text doesn't need to be drawn, but
         // the number column nearly always does.
-        (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true);
+        fold_count = foldedCount(wp, lnum, &win_foldinfo);
+        if (fold_count != 0) {
+          fold_line(wp, fold_count, &win_foldinfo, lnum, row);
+          --fold_count;
+        } else {
+          (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true);
+        }
       }
 
       // This line does not need to be drawn, advance to the next one.

--- a/src/nvim/screen.c
+++ b/src/nvim/screen.c
@@ -1463,7 +1463,6 @@ static void win_update(win_T *wp)
         fold_count = foldedCount(wp, lnum, &win_foldinfo);
         if (fold_count != 0) {
           fold_line(wp, fold_count, &win_foldinfo, lnum, row);
-          --fold_count;
         } else {
           (void)win_line(wp, lnum, srow, wp->w_grid.Rows, true, true);
         }

--- a/src/nvim/testdir/test_fold.vim
+++ b/src/nvim/testdir/test_fold.vim
@@ -1,6 +1,7 @@
 " Test for folding
 
 source view_util.vim
+source screendump.vim
 
 func PrepIndent(arg)
   return [a:arg] + repeat(["\t".a:arg], 5)
@@ -719,4 +720,24 @@ func Test_folds_marker_in_comment2()
 
   set foldmethod&
   bwipe!
+endfunc
+
+func Test_folds_with_rnu()
+  if !CanRunVimInTerminal()
+    return
+  endif
+
+  call writefile([
+	\ 'set fdm=marker rnu foldcolumn=2',
+	\ 'call setline(1, ["{{{1", "nline 1", "{{{1", "line 2"])',
+	\ ], 'Xtest_folds_with_rnu')
+  let buf = RunVimInTerminal('-S Xtest_folds_with_rnu', {})
+
+  call VerifyScreenDump(buf, 'Test_folds_with_rnu_01', {})
+  call term_sendkeys(buf, "j")
+  call VerifyScreenDump(buf, 'Test_folds_with_rnu_02', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  call delete('Xtest_folds_with_rnu')
 endfunc


### PR DESCRIPTION
#### vim-patch:8.1.0449: when 'rnu' is set folded lines are not displayed correctly

Problem:    When 'rnu' is set folded lines are not displayed correctly.
            (Vitaly Yashin)
Solution:   When only redrawing line numbers do draw folded lines.
            (closes vim/vim#3484)
https://github.com/vim/vim/commit/7701f308565fdc7b5096a6597d9c3b63de0bbcec


#### vim-patch:8.1.0450: build failure without the +fold feature

Problem:    Build failure without the +fold feature.
Solution:   Add #ifdef.
https://github.com/vim/vim/commit/0e9deefb4fb4f99d0ab90b21ca38260be26bf5de